### PR TITLE
Fix markdown filetype notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **For yarn**
 
-``` sh
+```sh
 yarn global add vim-language-server
 ```
 
@@ -33,7 +33,7 @@ npm install -g vim-language-server
 
 **For coc.nvim user** install coc extension:
 
-``` vim
+```vim
 :CocInstall coc-vimlsp
 ```
 
@@ -41,7 +41,7 @@ npm install -g vim-language-server
 
 for document highlight
 
-``` vim
+```vim
 let g:markdown_fenced_languages = [
       \ 'vim',
       \ 'help'
@@ -52,7 +52,7 @@ lsp client config example with coc.nvim
 
 - Using node ipc
 
-``` jsonc
+```jsonc
 "languageserver": {
   "vimls": {
     "module": "/path/to/vim-language-server/bin/index.js",
@@ -82,7 +82,7 @@ lsp client config example with coc.nvim
 
 - Using stdio
 
-``` jsonc
+```jsonc
 "languageserver": {
   "vimls": {
     "command": "vim-language-server",

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -100,7 +100,7 @@ export async function findProjectRoot(
 
 export function markupSnippets(snippets: string): string {
   return [
-    "``` vim",
+    "```vim",
     snippets.replace(/\$\{[0-9]+(:([^}]+))?\}/g, "$2"),
     "```",
   ].join("\n");

--- a/src/server/builtin.ts
+++ b/src/server/builtin.ts
@@ -284,7 +284,7 @@ class Builtin {
     return {
       kind: MarkupKind.Markdown,
       value: [
-        "``` help",
+        "```help",
         ...document.map((line) => {
           if (indent === 0) {
             const m = line.match(/^([ \t]+)/);


### PR DESCRIPTION
Remove extra space after three backtick.

That's how is documented in github flavoured markup documentation:

https://guides.github.com/features/mastering-markdown/

It also breaks the nvim lsp highlighter:
https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua#L396