### PR TITLE
fix(rename's prepareSupport) Add per-client checker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import logger from "./common/logger";
 
 // lsp initialize
 connection.onInitialize((param: InitializeParams) => {
+  const renamePrepareSupport = param.capabilities.textDocument && param.capabilities.textDocument.rename && param.capabilities.textDocument.rename.prepareSupport === true;
   const { initializationOptions = {} } = param;
   const {
     isNeovim,
@@ -93,9 +94,9 @@ connection.onInitialize((param: InitializeParams) => {
       },
       definitionProvider: true,
       referencesProvider: true,
-      renameProvider: {
+      renameProvider: renamePrepareSupport ? {
         prepareProvider: true,
-      },
+      } : true,
     },
   };
 });


### PR DESCRIPTION
Hello, maintainer.
Thanks for your create these tools!
I used vim-language-server with vim's vim-lsp (not neovim).
However, rename feature did not work on vim-lsp.
After investigating, I found out that the problem was caused by the prepare decision in rename.
So, I changed the source code based on the implementation of language server where prepare of rename is enabled and it works fine with vim-lsp.
Could you please review this patch?

## reference

> https://github.com/prabirshrestha/vim-lsp
> https://github.com/rcjsuen/dockerfile-language-server-nodejs/blob/master/src/server.ts#L237-L239