### PR TITLE
Fix for "error: Timeout 10000ms"

### DIFF
--- a/src/server/parser.ts
+++ b/src/server/parser.ts
@@ -131,7 +131,7 @@ export function next(
             text: td.getText()
           })
         })).pipe(
-          timeout(10000),
+          timeout(50000),
           catchError(() => {
             if (parserCallbacks[id]) {
               delete parserCallbacks[id]
@@ -140,7 +140,7 @@ export function next(
             scanProcess = undefined
             return of({
               res: '',
-              error: `Timeout: 10000ms`,
+              error: `Timeout: 50000ms`,
               isTimeout: true,
             })
           })


### PR DESCRIPTION
Hi,

In my environment (macOS, M1, 16GB, fresh installation of neovim 0.5), I can't use vim-language-server because it keeps saying "error: Timeout 10000ms".

The problem lies in **hardcoded** timeout, not in my computer's performance or vimrc.

Screenshot with minimal vimrc is attached below.
<img width="1494" alt="Screenshot 2021-08-20 22 19 40" src="https://user-images.githubusercontent.com/78744464/130973173-51269c65-1c67-4af5-9182-61fecfac9cad.png">

Best regards,
Kenichi