### PR TITLE
fix: handlers wait for buffer to be loaded

### DIFF
--- a/src/handles/documentSymbol.ts
+++ b/src/handles/documentSymbol.ts
@@ -6,10 +6,10 @@ import {IFunction, IIdentifier} from "../server/buffer";
 import {documents} from "../server/documents";
 import config from "../server/config";
 
-export const documentSymbolProvider = (params: DocumentSymbolParams): DocumentSymbol[] | SymbolInformation[] => {
+export const documentSymbolProvider = async (params: DocumentSymbolParams): Promise<DocumentSymbol[] | SymbolInformation[]> => {
   const documentSymbols: DocumentSymbol[] = []
   const { textDocument } = params
-  const buffer = workspace.getBufferByUri(textDocument.uri)
+  const buffer = await workspace.getBufferByUri(textDocument.uri)
   const document = documents.get(textDocument.uri)
   if (!buffer || !document) {
     return documentSymbols

--- a/src/handles/foldingRange.ts
+++ b/src/handles/foldingRange.ts
@@ -2,10 +2,10 @@ import {FoldingRange, FoldingRangeParams} from "vscode-languageserver";
 
 import {workspace} from "../server/workspaces";
 
-export const foldingRangeProvider = (params: FoldingRangeParams) => {
+export const foldingRangeProvider = async (params: FoldingRangeParams) => {
   const res: FoldingRange[] = [];
   const { textDocument } = params;
-  const buffer = workspace.getBufferByUri(textDocument.uri);
+  const buffer = await workspace.getBufferByUri(textDocument.uri);
   if (!buffer) {
     return res;
   }

--- a/src/handles/selectionRange.ts
+++ b/src/handles/selectionRange.ts
@@ -3,13 +3,13 @@ import {SelectionRangeParams, SelectionRange, Range, Position} from "vscode-lang
 import {workspace} from "../server/workspaces";
 import {documents} from "../server/documents";
 
-export const selectionRangeProvider = (params: SelectionRangeParams): SelectionRange[] => {
+export const selectionRangeProvider = async (params: SelectionRangeParams): Promise<SelectionRange[]> => {
   const selectRanges: SelectionRange[] = [];
   const { textDocument, positions } = params;
   if (!positions || positions.length === 0) {
     return selectRanges
   }
-  const buffer = workspace.getBufferByUri(textDocument.uri);
+  const buffer = await workspace.getBufferByUri(textDocument.uri);
   const document = documents.get(textDocument.uri)
   if (!buffer || !document) {
     return selectRanges;


### PR DESCRIPTION
This came from a bug report here: https://github.com/stevearc/aerial.nvim/issues/68

When opening a new vim file, there is a short window of time when the workspace is still finding the root dir and has not yet populated `this.buffers[uri]`, though it has registered the *intent* to load it. This was causing issues where requests made immediately after opening a file (e.g. `documentSymbol`) would trigger the early-return case because `!buffer`.

This change makes it so that as soon as we have the intent to load a new Buffer, that promise is stored. The `getBufferByUri` method returns a Promise now, and all callsites have been updated. If the Buffer is already loaded, it is returned immediately. If there is a Promise for that uri, it is returned. Only if both of those are false does it return `undefined`.

## Test plan
- `yarn lint && yarn test`
- I have run this patch in my normal editor configuration and both diagnostics and document symbols appear to work as expected