### PR TITLE
feat(vint): support vint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - select range
 - rename
 - snippets
-- diagnostic
+- diagnostic, include support for [vint](https://github.com/Vimjas/vint)
 
 ![autocomplete](https://user-images.githubusercontent.com/5492542/81493984-909c2e80-92d7-11ea-9638-d7be3e18e1d1.gif)
 

--- a/src/handles/diagnostic.ts
+++ b/src/handles/diagnostic.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from "child_process";
 import {
   DiagnosticSeverity,
   Position,
   Range,
   TextDocument,
 } from "vscode-languageserver";
+import { URI } from 'vscode-uri'
 import { errorLinePattern } from "../common/patterns";
 import { connection } from "../server/connection";
 
@@ -17,29 +19,55 @@ const fixNegativeNum = (num: number): number => {
 export async function handleDiagnostic(
   textDoc: TextDocument,
   error: string,
+  save: boolean,
 ) {
+  let diagnostics = []
+  if (save) {
+    let cp = spawnSync("vint", [URI.parse(textDoc.uri).fsPath], { encoding: "utf8" });
+    if (cp.stdout) {
+      // example output:
+      //   "/home/wzy/.config/nvim/init.vim:21:3: warning! " "Do not use nocompatible which has unexpected effects(:help nocompatible)"
+      for (let line of cp.stdout.trim().split("\n")) {
+        let [_1, info, _2, message, _3] = line.split('"');
+        let [_path, _row, _col, _severity] = info.split(":");
+        let row = Number(_row);
+        let col = Number(_col);
+        _severity = _severity.trim().replace("!", "");
+        let severity: DiagnosticSeverity = DiagnosticSeverity.Error;
+        if (_severity === "warning") {
+          severity = DiagnosticSeverity.Warning;
+        }
+        diagnostics = [...diagnostics, {
+          source: "vint",
+          message: message,
+          range: Range.create(
+            Position.create(row - 1, col - 1),
+            Position.create(row, 0),
+          ),
+          severity: severity,
+        }];
+      }
+    }
+  }
+
   const m = (error || "").match(errorLinePattern);
   if (m) {
     const lines = textDoc.lineCount;
     const line = fixNegativeNum(parseFloat(m[2]) - 1);
     const col = fixNegativeNum(parseFloat(m[3]) - 1);
-    return connection.sendDiagnostics({
-      uri: textDoc.uri,
-      diagnostics: [{
-        source: "vimlsp",
-        message: m[1],
-        range: Range.create(
-          Position.create(line > lines ? lines : line, col),
-          Position.create(line > lines ? lines : line, col + 1),
-        ),
-        severity: DiagnosticSeverity.Error,
-      }],
-    });
+    diagnostics = [...diagnostics, {
+      source: "vimlsp",
+      message: m[1],
+      range: Range.create(
+        Position.create(line > lines ? lines : line, col),
+        Position.create(line > lines ? lines : line, col + 1),
+      ),
+      severity: DiagnosticSeverity.Error,
+    }];
   }
 
-  // clear diagnostics
-  connection.sendDiagnostics({
+  return connection.sendDiagnostics({
     uri: textDoc.uri,
-    diagnostics: [],
+    diagnostics: diagnostics,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,15 @@ connection.onInitialize((param: InitializeParams) => {
 
 // document change or open
 documents.onDidChangeContent(( change ) => {
-  next(change.document);
+  next(change.document, false);
+});
+
+documents.onDidOpen(( change ) => {
+  next(change.document, true);
+});
+
+documents.onDidSave(( change ) => {
+  next(change.document, true);
 });
 
 documents.onDidClose((evt) => {

--- a/src/server/parser.ts
+++ b/src/server/parser.ts
@@ -111,6 +111,7 @@ function startIndex() {
 
 export function next(
   textDoc: TextDocument,
+  save: boolean,
 ) {
   if (!parserHandles[textDoc.uri]) {
     const { uri } = textDoc;
@@ -152,7 +153,7 @@ export function next(
         if (res) {
           if (config.diagnostic.enable) {
             // handle diagnostic
-            handleDiagnostic(textDoc, res[1]);
+            handleDiagnostic(textDoc, res[1], save);
           }
           // handle node
           workspace.updateBuffer(uri, res[0]);


### PR DESCRIPTION
Fix #97

Work for me:

```json
    "vim": {
      "command": "/home/wzy/Desktop/vim-language-server/bin/index.js",
      "args": ["--stdio"],
      "filetypes": ["vim"]
    },
```

PS: https://github.com/google/vimscript-language-server claim it will support lint, however it have stopped development.